### PR TITLE
Clearly specifying 0.9 as the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ migrate to the latest version.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'google-api-client'
+gem 'google-api-client', '0.9.pre1'
+
 ```
 
 And then execute:


### PR DESCRIPTION
A gem 'google-api-client' will give the developer version 0.8.6, not 0.9. The smallest solution is to update the readme. This better communicates that the gem is going through some large changes.
